### PR TITLE
Improve docs by removing confusion with AWS env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ _Variables in bold are required._
 | Name                        | Default            | Description                                                                    |
 | --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
 | SQS_INDEXER_QUEUE_URL       | indexerQueue       | The SQS topic to publish message to indexing subsystem                         |
+
+Also check [AWS specific configuration](https://github.com/elastic-ipfs/elastic-ipfs/blob/main/aws.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ _Variables in bold are required._
 
 | Name                        | Default            | Description                                                                    |
 | --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
-| SQS_INDEXER_QUEUE_URL       | indexerQueue       | The SQS topic to publish message to indexing subsystem                         |
 | SNS_EVENTS_TOPIC            | eventsTopic        | The topic on which to publish elastic-ipfs events                              |
 | SQS_INDEXER_QUEUE_REGION    |                    | region of SQS topic to publish message to indexing subsystem                   |
 | SQS_INDEXER_QUEUE_URL       | indexerQueue       | The SQS topic to publish message to indexing subsystem                         |

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ _Variables in bold are required._
 | --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
 | SQS_INDEXER_QUEUE_URL       | indexerQueue       | The SQS topic to publish message to indexing subsystem                         |
 
-Also check [AWS specific configuration](https://github.com/elastic-ipfs/elastic-ipfs/blob/main/aws.md).
+Also check [AWS specifics configuration](https://github.com/elastic-ipfs/elastic-ipfs/blob/main/aws.md).


### PR DESCRIPTION
Remove AWS specific env vars and link to AWS configuration doc. Also removing CICD specific environment variables. Current doc is generating confusion. Developers often think that is necessary to configure long living keys inside lambda and EC2